### PR TITLE
Upload-artifact version change 

### DIFF
--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -1,10 +1,10 @@
 name: Combine Data and Upload
 
-on: workflow_dispatch
-#  workflow_run:
-#    workflows: [Crawl Heartland Hub]
-#    types:
-#      - completed
+on:
+  workflow_run:
+    workflows: [Crawl Heartland Hub]
+    types:
+      - completed
 
 jobs:
   on-success:

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -37,12 +37,12 @@ jobs:
         working-directory: ./
         run: python combine.py
       - name: Upload jsonl to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mohub_ingest
           path: mohub_ingest.jsonl
       - name: Upload ingest report to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ingest_report
           path: report.txt

--- a/.github/workflows/combine.yml
+++ b/.github/workflows/combine.yml
@@ -1,10 +1,10 @@
 name: Combine Data and Upload
 
-on:
-  workflow_run:
-    workflows: [Crawl Heartland Hub]
-    types:
-      - completed
+on: workflow_dispatch
+#  workflow_run:
+#    workflows: [Crawl Heartland Hub]
+#    types:
+#      - completed
 
 jobs:
   on-success:

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -27,7 +27,7 @@ jobs:
       working-directory: ./
       run: python main.py -i $id
     - name: Upload crawl data to artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.id }}_data
         path: ${{ env.id }}.json
@@ -56,7 +56,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -85,7 +85,7 @@ jobs:
   #      working-directory: ./
   #      run: python main.py -i $id
   #    - name: Upload crawl data to artifact
-  #      uses: actions/upload-artifact@v3
+  #      uses: actions/upload-artifact@v4
   #      with:
   #        name: ${{ env.id }}_data
   #        path: ${{ env.id }}.json
@@ -99,7 +99,7 @@ jobs:
        python-version: [ "3.8" ]
    steps:
      - name: checkout
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
        with:
          ref: ${{ github.ref }}
      - name: Set up Python ${{ matrix.python-version }}
@@ -114,7 +114,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -143,7 +143,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -157,7 +157,7 @@ jobs:
        python-version: [ "3.8" ]
    steps:
      - name: checkout
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
        with:
          ref: ${{ github.ref }}
      - name: Set up Python ${{ matrix.python-version }}
@@ -172,7 +172,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -201,7 +201,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -230,7 +230,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -259,7 +259,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -288,7 +288,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -317,7 +317,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -345,7 +345,7 @@ jobs:
   #      working-directory: ./
   #      run: python main.py -i $id
   #    - name: Upload crawl data to artifact
-  #      uses: actions/upload-artifact@v3
+  #      uses: actions/upload-artifact@v4
   #      with:
   #        name: ${{ env.id }}_data
   #        path: ${{ env.id }}.json
@@ -373,7 +373,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -401,7 +401,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -429,38 +429,38 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
-  crawl_grinnell:
-   env:
-     id: grinnell
-   runs-on: ubuntu-latest
-   strategy:
-     matrix:
-       python-version: [ "3.8" ]
-   steps:
-     - name: checkout
-       uses: actions/checkout@v3
-       with:
-         ref: ${{ github.ref }}
-     - name: Set up Python ${{ matrix.python-version }}
-       uses: actions/setup-python@v3
-       with:
-         python-version: ${{ matrix.python-version }}
-     - name: Install dependencies
-       run: |
-         python -m pip install --upgrade pip
-         pip install -r requirements.txt
-     - name: crawl feed
-       working-directory: ./
-       run: python main.py -i $id
-     - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
-       with:
-         name: ${{ env.id }}_data
-         path: ${{ env.id }}.json
+  # crawl_grinnell:
+  # env:
+  #    id: grinnell
+  # runs-on: ubuntu-latest
+  # strategy:
+  #   matrix:
+  #     python-version: [ "3.8" ]
+  # steps:
+  #   - name: checkout
+  #     uses: actions/checkout@v3
+  #     with:
+  #       ref: ${{ github.ref }}
+  #   - name: Set up Python ${{ matrix.python-version }}
+  #     uses: actions/setup-python@v3
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #   - name: Install dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       pip install -r requirements.txt
+  #   - name: crawl feed
+  #     working-directory: ./
+  #     run: python main.py -i $id
+  #   - name: Upload crawl data to artifact
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: ${{ env.id }}_data
+  #       path: ${{ env.id }}.json
   crawl_uni:
    env:
      id: uni
@@ -485,7 +485,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json
@@ -511,7 +511,7 @@ jobs:
 #       working-directory: ./
 #       run: python main.py -i $id
 #     - name: Upload crawl data to artifact
-#       uses: actions/upload-artifact@v3
+#       uses: actions/upload-artifact@v4
 #       with:
 #         name: ${{ env.id }}_data
 #         path: ${{ env.id }}.json
@@ -539,7 +539,7 @@ jobs:
        working-directory: ./
        run: python main.py -i $id
      - name: Upload crawl data to artifact
-       uses: actions/upload-artifact@v3
+       uses: actions/upload-artifact@v4
        with:
          name: ${{ env.id }}_data
          path: ${{ env.id }}.json

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -99,7 +99,7 @@ jobs:
        python-version: [ "3.8" ]
    steps:
      - name: checkout
-       uses: actions/checkout@v4
+       uses: actions/checkout@v3
        with:
          ref: ${{ github.ref }}
      - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Upload-artifact@v3 has been deprecated; must update to v4 to run the workflow. Also, commenting out Grinnell for this quarter's harvest due to an in-progress repository migration.